### PR TITLE
Specify C3's OCaml dependencies via an opam package file.

### DIFF
--- a/C3.opam
+++ b/C3.opam
@@ -1,0 +1,18 @@
+# This file exists only to support convenient installation of C3's OCaml
+# dependencies using `opam install --deps-only .`. C3 itself currently is not
+# designed to be installed as an opam package.
+
+opam-version: "2.0"
+name: "C3"
+version: "0"
+synopsis: "Tool to convert Checked C code back to plain C"
+maintainer: "Correct Computation <info@correctcomputation.com>"
+depends: [
+  "dune"
+  # We saw a problem with menhir version 20211230 that we have not yet
+  # investigated. C3 seems to work with menhir version 20211128, so pin it for
+  # now.
+  "menhir" {= "20211128"}
+]
+# Prevent C3 from being installed as an opam package.
+build: ["false"]

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ C3 does not attempt to parse the full Checked C grammar. It parses just enough o
 
 # Setup
 
-Set up opam (see `opam init --help`), then run `opam install dune menhir` to install the OCaml dependencies. Make sure that regular (non Checked C) `clang` is on your `$PATH`.
+Set up opam (see `opam init --help`), then run `opam install --deps-only .` to install the OCaml dependencies. Make sure that regular (non Checked C) `clang` is on your `$PATH`.
 
 # Running, Examples
 


### PR DESCRIPTION
This way, external scripts to install C3 can just run `opam install --deps-only .` and not have to hard-code a list of OCaml dependencies that might change.